### PR TITLE
Change deployer to create template and use it

### DIFF
--- a/performance_testing/scripts/add_vms.py
+++ b/performance_testing/scripts/add_vms.py
@@ -7,11 +7,14 @@ import gevent
 import signal
 import time
 import os
+import sys
 from gevent.lock import BoundedSemaphore
+from JumpScale import j
 _cloudspace_semaphores = dict()
 _stats = dict(deployed_vms=0, deployed_cloudspaces=0)
 _vmnamecache = dict()
 
+TEMPLATE_NAME = 'performance_testing'
 
 logger = get_logger('add_vms')
 
@@ -22,178 +25,181 @@ def get_publicport_semaphore(cloudspace_id):
     return _cloudspace_semaphores[cloudspace_id]
 
 
-def get_cloudspace_template_vm_id(concurrency, ovc, cloudspace_id):
-    machine_name = get_vm_name(cloudspace_id, 0)
-    if machine_name in _vmnamecache:
-        return _vmnamecache[machine_name]
-    with get_publicport_semaphore(cloudspace_id):
-        if machine_name in _vmnamecache:
-            return _vmnamecache[machine_name]
-
-        machines = ovc.api.cloudapi.machines.list(cloudspaceId=cloudspace_id)
-        vm_id = next(m['id'] for m in machines if m['name'] == machine_name)
-
-        def stop():
-            print("Stopping machine {}".format(machine_name))
-            ovc.api.cloudapi.machines.stop(machineId=vm_id)
-
-        if concurrency is None:
-            stop()
-        else:
-            with concurrency:
-                stop()
-        while True:
-            gevent.sleep(1)
-            vm = safe_get_vm(ovc, concurrency, vm_id)
-            if vm['status'] == 'HALTED':
-                break
-        _vmnamecache[machine_name] = vm_id
-        return vm_id
-
-
-def install_req(ovc, machine, cloudspace, public_port, name):
-    account = machine['accounts'][0]
-
-    # Wait until vm accepts connections
-    wait_until_remote_is_listening(cloudspace['publicipaddress'], public_port)
-
-    # Copy install_deps.sh to vm
-    templ = 'sshpass -p "{0}" scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-    templ += ' -P {1} install_deps.sh {2}@{3}:/home/{2}'
-    cmd = templ.format(account['password'], public_port, account['login'], cloudspace['publicipaddress'])
-    run_cmd_via_gevent(cmd)
-
-    # Run bash script on vm
-    templ = 'sshpass -p "{0}" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p {1} {2}@{3} '
-    templ += '\'echo "{0}" | sudo -S bash /home/{2}/install_deps.sh\''
-    cmd = templ.format(account['password'], public_port, account['login'], cloudspace['publicipaddress'])
-    run_cmd_via_gevent(cmd)
-
-
-def safe_deploy_vm(options, ovc, account_id, gid, name, cloudspace_id, image_id, force_create=False):
-    while True:
-        try:
-            deploy_vm(options, ovc, account_id, gid, name, cloudspace_id, image_id, force_create)
-            return
-        except Exception as e:
-            templ = "Failed creating machine {} in cloudspace {}, \nError: {}\nretrying ..."
-            logger.error(templ.format(name, cloudspace_id, str(e)))
-            gevent.sleep(10)
-            while True:
-                try:
-                    machines = ovc.api.cloudapi.machines.list(cloudspaceId=cloudspace_id)
-                    machine_id = next((m['id'] for m in machines if m['name'] == name), None)
-                    if machine_id is None:
-                        break
-                    ovc.api.cloudapi.machines.delete(machineId=machine_id)
-                    break
-                except Exception as e:
-                    templ = "Failed cleaning up machine {} in cloudspace {}, \nError: {}\nretrying ..."
-                    logger.error(templ.format(name, cloudspace_id, str(e)))
-                    gevent.sleep(10)
-
-
-def deploy_vm(options, ovc, account_id, gid, name, cloudspace_id, image_id, force_create=False):
-    # Listing sizes
-    sizes = ovc.api.cloudapi.sizes.list(cloudspaceId=cloudspace_id)
-    size_id = next((s['id'] for s in sizes if (options.bootdisk in s['disks'] and
-                                               options.memory == s['memory'] and
-                                               options.cpu == s['vcpus'])), None)
-    if size_id is None:
-        raise ValueError("No matching size for vm found.")
-
-    if options.iops < 0:
-        raise ValueError("Maximum iops can't be a negative value")
-
-    clone = options.clone and not force_create
-
-    # Create vm
-    with concurrency:
-        if clone:
-            print("Cloning {}".format(name))
-            template_vm_id = get_cloudspace_template_vm_id(None, ovc, cloudspace_id)
-            vm_id = ovc.api.cloudapi.machines.clone(machineId=template_vm_id, name=name)
-        else:
-            print("Creating {}".format(name))
-            vm_id = ovc.api.cloudapi.machines.create(cloudspaceId=cloudspace_id,
-                                                     name=name,
-                                                     description=name,
-                                                     sizeId=size_id,
-                                                     imageId=image_id,
-                                                     disksize=options.bootdisk,
-                                                     datadisks=[int(options.datadisk)])
-
-    # limit the IOPS on all the disks of the vm
-    machine = safe_get_vm(ovc, concurrency, vm_id)
-    for disk in machine['disks']:
-        if disk['type'] != 'D':
-            continue
-        with concurrency:
-            print("Set limit of iops to {} on disk {}({}) for machine {}".format(options.iops,
-                                                                                 disk['name'],
-                                                                                 disk['id'],
-                                                                                 name))
-            ovc.api.cloudapi.disks.limitIO(diskId=disk['id'], iops=options.iops)
-
-    # Wait until vm has ip address
-    start = time.time()
-    while True:
-        gevent.sleep(5)
-        machine = safe_get_vm(ovc, concurrency, vm_id)
-        ip = machine['interfaces'][0]['ipAddress']
-        if ip != 'Undefined':
-            break
-        now = time.time()
-        if now > start + 600:
-            raise RuntimeError("Machine {} did not get an ip within 600 seconds".format(vm_id))
-        print("Waiting {} seconds for an IP for VM {}".format(int(now - start), name))
-
-    # Configure portforward to ssh port of vm
-    print("Configuring portforward for machine {}".format(name))
-    cloudspace = ovc.api.cloudapi.cloudspaces.get(cloudspaceId=cloudspace_id)
-    with get_publicport_semaphore(cloudspace_id):
-        public_ports = [int(pf['publicPort']) for pf in ovc.api.cloudapi.portforwarding.list(cloudspaceId=cloudspace_id)]
-        public_ports.append(19999)
-        public_port = max(public_ports) + 1
-        with concurrency:
-            ovc.api.cloudapi.portforwarding.create(cloudspaceId=cloudspace_id,
-                                                   publicIp=cloudspace['publicipaddress'],
-                                                   publicPort=public_port,
-                                                   machineId=vm_id,
-                                                   localPort=22,
-                                                   protocol='tcp')
-
-    if not clone:
-        # Install fio & unixbench via cuisine on the vm
-        install_req(ovc, machine, cloudspace, public_port, name)
-
-    print("Machine {} deployed succesfully.".format(name))
-    _stats['deployed_vms'] += 1
-
-
 def get_vm_name(cloudspace_id, counter):
     return "vm-{0}-{1:0>3}".format(cloudspace_id, counter)
 
 
-def deploy_cloudspace(options, ovc, account_id, name, image_id, gid):
-    # Create cloudspace
-    print("Creating cloudspace {}".format(name))
-    cloudspace_id = ovc.api.cloudapi.cloudspaces.create(accountId=account_id,
-                                                        location=options.location,
-                                                        name=name,
-                                                        access=options.username)
-    # Create first vm to force the routeros deployment
-    print("Deploying first vm in cloudspace {}".format(name))
-    safe_deploy_vm(options, ovc, account_id, gid, get_vm_name(cloudspace_id, 0),
-                   cloudspace_id, image_id, force_create=True)
+class Deployer(object):
+    def __init__(self, options):
+        self.options = options
+        self.ovc = j.clients.openvcloud.get(options.environment,
+                                            options.username,
+                                            options.password)
 
-    # Deploy the remaining vms
-    jobs = [gevent.spawn(safe_deploy_vm, options, ovc, account_id, gid,
-                         get_vm_name(cloudspace_id, x),
-                         cloudspace_id, image_id) for x in range(1, options.vmachines)]
-    gevent.joinall(jobs)
+        # Get account id
+        print('Getting account id')
+        tmp = self.ovc.api.cloudapi.accounts.list()
+        if len(tmp) != 1:
+            print('FAILURE: Expected to only find 1 account and found {}'.format(len(tmp)))
+            return
+        self.account_id = tmp[0]['id']
 
-    _stats['deployed_cloudspaces'] += 1
+        # Get location gid
+        print('Getting location gid')
+        self.gid = next((loc['gid'] for loc in self.ovc.api.cloudapi.locations.list() if loc['locationCode'] == options.location), None)
+        if self.gid is None:
+            print('FAILURE: Could not determine gid')
+            sys.exit(1)
+
+    def create_performance_test_image(self):
+        image_id = next((img['id'] for img in self.ovc.api.cloudapi.images.list(accountId=self.account_id) if img['name'] == TEMPLATE_NAME), None)
+        if image_id:
+            print('Found template for performance_testing')
+            return image_id
+        print('Checking if source image is available')
+        image_id = next((img['id'] for img in self.ovc.api.cloudapi.images.list() if img['name'] == options.image), None)
+        if image_id is None:
+            print('FAILURE: Could not find image.')
+            sys.exit(1)
+
+        print('Creating template_space')
+        cloudspace_id = self.deploy_cloudspace('template_space')
+        machine = self.safe_deploy_vm('template_vm', cloudspace_id, image_id)
+        cloudspace = self.ovc.api.cloudapi.cloudspaces.get(cloudspaceId=cloudspace_id)
+        print('Installing requirements')
+        self.install_req(machine, cloudspace)
+        print('Stopping template vm')
+        self.ovc.api.cloudapi.machines.stop(machineId=machine['id'])
+        print('Making template')
+        templateid = self.ovc.api.cloudapi.machines.createTemplate(machineId=machine['id'], templatename=TEMPLATE_NAME)
+        print('Remove portforwarding from templatevm')
+        self.ovc.api.cloudapi.portforwarding.deleteByPort(cloudspaceId=cloudspace_id,
+                                                          publicIp=cloudspace['externalnetworkip'],
+                                                          publicPort=machine['public_port'],
+                                                          proto='tcp')
+        return templateid
+
+    def install_req(self, machine, cloudspace):
+        account = machine['accounts'][0]
+
+        # Wait until vm accepts connections
+        wait_until_remote_is_listening(cloudspace['publicipaddress'], machine['public_port'])
+
+        # Copy install_deps.sh to vm
+        templ = 'sshpass -p "{0}" scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+        templ += ' -P {1} install_deps.sh {2}@{3}:/home/{2}'
+        cmd = templ.format(account['password'], machine['public_port'], account['login'], cloudspace['externalnetworkip'])
+        run_cmd_via_gevent(cmd)
+
+        # Run bash script on vm
+        templ = 'sshpass -p "{0}" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p {1} {2}@{3} '
+        templ += '\'echo "{0}" | sudo -S bash /home/{2}/install_deps.sh\''
+        cmd = templ.format(account['password'], machine['public_port'], account['login'], cloudspace['externalnetworkip'])
+        run_cmd_via_gevent(cmd)
+
+    def safe_deploy_vm(self, name, cloudspace_id, image_id, datadisk=None, iops=None):
+        while True:
+            try:
+                return self.deploy_vm(name, cloudspace_id, image_id, datadisk, iops)
+            except Exception as e:
+                templ = "Failed creating machine {} in cloudspace {}, \nError: {}\nretrying ..."
+                logger.error(templ.format(name, cloudspace_id, str(e)))
+                gevent.sleep(10)
+                while True:
+                    try:
+                        machines = self.ovc.api.cloudapi.machines.list(cloudspaceId=cloudspace_id)
+                        machine_id = next((m['id'] for m in machines if m['name'] == name), None)
+                        if machine_id is None:
+                            break
+                        self.ovc.api.cloudapi.machines.delete(machineId=machine_id)
+                        break
+                    except Exception as e:
+                        templ = "Failed cleaning up machine {} in cloudspace {}, \nError: {}\nretrying ..."
+                        logger.error(templ.format(name, cloudspace_id, str(e)))
+                        gevent.sleep(10)
+
+    def deploy_vm(self, name, cloudspace_id, image_id, datadisk=None, iops=None):
+        # Listing sizes
+        sizes = self.ovc.api.cloudapi.sizes.list(cloudspaceId=cloudspace_id)
+        size_id = next((s['id'] for s in sizes if (self.options.bootdisk in s['disks'] and
+                                                   self.options.memory == s['memory'] and
+                                                   self.options.cpu == s['vcpus'])), None)
+        if size_id is None:
+            raise ValueError("No matching size for vm found.")
+
+        if options.iops < 0:
+            raise ValueError("Maximum iops can't be a negative value")
+
+        # Create vm
+        with concurrency:
+            print("Creating {}".format(name))
+            datadisks = [int(datadisk)] if datadisk else []
+            vm_id = self.ovc.api.cloudapi.machines.create(cloudspaceId=cloudspace_id,
+                                                          name=name,
+                                                          description=name,
+                                                          sizeId=size_id,
+                                                          imageId=image_id,
+                                                          disksize=options.bootdisk,
+                                                          datadisks=datadisks)
+
+        # limit the IOPS on all the disks of the vm
+        machine = safe_get_vm(self.ovc, concurrency, vm_id)
+        if iops is not None:
+            for disk in machine['disks']:
+                if disk['type'] != 'D':
+                    continue
+                with concurrency:
+                    print("Set limit of iops to {} on disk {}({}) for machine {}".format(options.iops,
+                                                                                         disk['name'],
+                                                                                         disk['id'],
+                                                                                         name))
+                    self.ovc.api.cloudapi.disks.limitIO(diskId=disk['id'], iops=iops)
+
+        # Wait until vm has ip address
+        start = time.time()
+        while True:
+            gevent.sleep(5)
+            machine = safe_get_vm(self.ovc, concurrency, vm_id)
+            ip = machine['interfaces'][0]['ipAddress']
+            if ip != 'Undefined':
+                break
+            now = time.time()
+            if now > start + 600:
+                raise RuntimeError("Machine {} did not get an ip within 600 seconds".format(vm_id))
+            print("Waiting {} seconds for an IP for VM {}".format(int(now - start), name))
+
+        # Configure portforward to ssh port of vm
+        print("Configuring portforward for machine {}".format(name))
+        cloudspace = self.ovc.api.cloudapi.cloudspaces.get(cloudspaceId=cloudspace_id)
+        with get_publicport_semaphore(cloudspace_id):
+            public_ports = [int(pf['publicPort']) for pf in self.ovc.api.cloudapi.portforwarding.list(cloudspaceId=cloudspace_id)]
+            public_ports.append(19999)
+            public_port = max(public_ports) + 1
+            with concurrency:
+                self.ovc.api.cloudapi.portforwarding.create(cloudspaceId=cloudspace_id,
+                                                            publicIp=cloudspace['publicipaddress'],
+                                                            publicPort=public_port,
+                                                            machineId=vm_id,
+                                                            localPort=22,
+                                                            protocol='tcp')
+        machine['public_port'] = public_port
+        print("Machine {} deployed succesfully.".format(name))
+        _stats['deployed_vms'] += 1
+        return machine
+
+    def deploy_cloudspace(self, name):
+        # Create cloudspace
+        with concurrency:
+            print("Creating cloudspace {}".format(name))
+            cloudspace_id = self.ovc.api.cloudapi.cloudspaces.create(accountId=self.account_id,
+                                                                     location=options.location,
+                                                                     name=name,
+                                                                     access=options.username)
+
+            print("Deploying cloudspace {}".format(name))
+            self.ovc.api.cloudapi.cloudspaces.deploy(cloudspaceId=cloudspace_id)
+            _stats['deployed_cloudspaces'] += 1
+            return cloudspace_id
 
 
 def main(options):
@@ -203,61 +209,31 @@ def main(options):
               " is in the current directory and sshpass is installed.")
         return
 
-    from JumpScale import j
-    ovc = j.clients.openvcloud.get(options.environment,
-                                   options.username,
-                                   options.password)
+    deployer = Deployer(options)
     # Can we find the image we need ?
-    print('Checking if image is available')
-    image_id = next((img['id'] for img in ovc.api.cloudapi.images.list() if img['name'] == options.image), None)
-    if image_id is None:
-        print('FAILURE: Could not find image.')
-        return
+    templateimage_id = deployer.create_performance_test_image()
 
-    # Get account id
-    print('Getting account id')
-    tmp = ovc.api.cloudapi.accounts.list()
-    if len(tmp) != 1:
-        print('FAILURE: Expected to only find 1 account and found {}'.format(len(tmp)))
-        return
-    account_id = tmp[0]['id']
-
-    # Get location gid
-    print('Getting location gid')
-    gid = next((loc['gid'] for loc in ovc.api.cloudapi.locations.list() if loc['locationCode'] == options.location),
-               None)
-    if gid is None:
-        print('FAILURE: Could not determine gid')
-        return
-
-    # Create cloudspaces if needed
     jobs = list()
     print('Checking if we need more cloudspaces')
-    cloudspaces = ovc.api.cloudapi.cloudspaces.list()
+    cloudspaces = list(filter(lambda space: space['name'].startswith('space-'), deployer.ovc.api.cloudapi.cloudspaces.list()))
     if len(cloudspaces) < options.cloudspaces:
-        jobs.extend([gevent.spawn(deploy_cloudspace, options, ovc, account_id,
-                                  'space-{0:0>3}'.format(x), image_id,
-                                  gid) for x in range(len(tmp), int(options.cloudspaces) + 1)])
+        jobs.extend([gevent.spawn(deployer.deploy_cloudspace, 'space-{0:0>3}'.format(x))
+                     for x in range(len(cloudspaces) + 1, int(options.cloudspaces) + 1)])
 
+    gevent.joinall(jobs)
+    jobs = list()
     # Add vms in existing cloudspaces
+    cloudspaces = list(filter(lambda space: space['name'].startswith('space-'), deployer.ovc.api.cloudapi.cloudspaces.list()))
     print('Checking if we need more vms in existing cloudspaces')
     for cloudspace in cloudspaces:
         cloudspace_id = cloudspace['id']
-        expected_vms = [get_vm_name(cloudspace_id, x) for x in range(0, options.vmachines)]
-        for vm in ovc.api.cloudapi.machines.list(cloudspaceId=cloudspace_id):
+        expected_vms = [get_vm_name(cloudspace_id, x) for x in range(1, options.vmachines + 1)]
+        for vm in deployer.ovc.api.cloudapi.machines.list(cloudspaceId=cloudspace_id):
             if vm['name'] in expected_vms:
                 expected_vms.remove(vm['name'])
-        jobs.extend([gevent.spawn(safe_deploy_vm, options, ovc, account_id, gid,
-                                  vm_name, cloudspace_id, image_id)
+        jobs.extend([gevent.spawn(deployer.safe_deploy_vm, vm_name, cloudspace_id, templateimage_id, options.datadisk, options.iops)
                      for vm_name in expected_vms])
     gevent.joinall(jobs)
-
-    # Start template vms
-    for cloudspace in cloudspaces:
-        cloudspace_id = cloudspace['id']
-        print("Starting machine {}".format(get_vm_name(cloudspace_id, 0)))
-        ovc.api.cloudapi.machines.start(machineId=get_cloudspace_template_vm_id(concurrency, ovc, cloudspace_id))
-
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -287,8 +263,6 @@ if __name__ == "__main__":
                         help="maximum of iops of the disks for the virtual machines")
     parser.add_argument("-n", "--con", dest="concurrency", default=2, type=int,
                         help="amount of concurrency to execute the job")
-    parser.add_argument("-s", "--clone", dest="clone", default=1, type=int,
-                        help="clone the first vm in the cloudspace (000)")
 
     options = parser.parse_args()
     concurrency = BoundedSemaphore(options.concurrency)


### PR DESCRIPTION
Refactor script to work as a class
Completly remove the clonining way.

Script now creates a template for the account and uses it
for all machines.

Script makes sure cloudspaces get deployed in parrallel by
invoking cloudspaces.deploy manually.
