### PR TITLE
Task 294

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/ACL/a_basic_operations/acl_cloudspace_test.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/ACL/a_basic_operations/acl_cloudspace_test.py
@@ -466,29 +466,29 @@ class Write(ACLCLOUDSPACE):
         self.lg('4- Update portforwarding with new ports')
         portforwarding_id = portforwarding[0]['id']
         cs_publicip = portforwarding[0]['publicIp']
-        new_cs_publicport = random.randint(1000, 65000)
+        new_public_port = random.randint(1000, 65000)
         new_vm_port = 22
         self.user_api.cloudapi.portforwarding.update(cloudspaceId=self.cloudspace_id,
                                                      id=portforwarding_id,
                                                      publicIp=cs_publicip,
-                                                     publicPort=new_cs_publicport,
+                                                     publicPort=new_public_port,
                                                      machineId=machine_id,
                                                      localPort=new_vm_port,
                                                      protocol='tcp')
 
         portforwarding = self.user_api.cloudapi.portforwarding.list(cloudspaceId=self.cloudspace_id, machineId=machine_id)
         self.assertEqual(len(portforwarding), 1, "Failed to get the port forwarding for machine[%s]" % machine_id)
-        self.assertEqual(int(portforwarding[0]['publicPort']), new_cs_publicport)
+        self.assertEqual(int(portforwarding[0]['publicPort']), new_public_port)
         self.assertEqual(int(portforwarding[0]['localPort']), new_vm_port)
 
         self.lg('Try to connect to the virtual machine (VM1), should succeed')
-        machine_client = VMClient(machine_id, port=new_cs_publicport)
+        machine_client = VMClient(machine_id, port=new_public_port)
         stdin, stdout, stderr = machine_client.execute('hostname')
         self.assertEqual('vm-{}'.format(machine_id), stdout.read().strip())
 
         self.lg('Try to connect to the virtual machine (VM1) using the old public port, should fail')
         with self.assertRaises(VMConnectionError) as e:
-            VMClient(machine_id, port=new_cs_publicport)
+            VMClient(machine_id, port=public_port, timeout=5)
     
 
 

--- a/functional_testing/Openvcloud/ovc_master_hosted/ACL/a_basic_operations/acl_cloudspace_test.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/ACL/a_basic_operations/acl_cloudspace_test.py
@@ -461,7 +461,7 @@ class Write(ACLCLOUDSPACE):
         self.lg('Try to connect to the virtual machine (VM1), should succeed')
         machine_client = VMClient(machine_id, port=public_port)        
         stdin, stdout, stderr = machine_client.execute('hostname')
-        self.assertEqual('vm-{}'.format(machine_id), stdout.read().split())
+        self.assertEqual('vm-{}'.format(machine_id), stdout.read().strip())
 
         self.lg('4- Update portforwarding with new ports')
         portforwarding_id = portforwarding[0]['id']
@@ -484,7 +484,7 @@ class Write(ACLCLOUDSPACE):
         self.lg('Try to connect to the virtual machine (VM1), should succeed')
         machine_client = VMClient(machine_id, port=new_cs_publicport)
         stdin, stdout, stderr = machine_client.execute('hostname')
-        self.assertEqual('vm-{}'.format(machine_id), stdout.read().split())
+        self.assertEqual('vm-{}'.format(machine_id), stdout.read().strip())
 
         self.lg('Try to connect to the virtual machine (VM1) using the old public port, should fail')
         with self.assertRaises(VMConnectionError) as e:


### PR DESCRIPTION
fixes #294 
```
root@be-g8-3:/tmp/ahmed/G8_testing/functional_testing/Openvcloud# nosetests -v -s ovc_master_hosted/ACL/a_basic_operations/acl_cloudspace_test.py:Write.test004_cloudspace_portforwarding_add_update_delete --tc-file=config.ini 
ACL-32 ... ok

----------------------------------------------------------------------
Ran 1 test in 157.321s

OK
```