### PR TITLE
Check that the cloned vm has one boot disk and one metadata disk

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/c_advanced/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/c_advanced/machine_tests.py
@@ -381,6 +381,7 @@ class MachineTests(BasicACLTest):
         #. Write file (F1) on (VM1).
         #. Stop (VM1), should succeed.
         #. Clone VM1 as (VM2_C), should succeed.
+        #. Check that the cloned vm has one boot disk and one metadata disk.
         #. Start (VM1), should succeed
         #. Make sure VM2_C got a new ip.
         #. Make sure no portforwards have been created.
@@ -410,6 +411,12 @@ class MachineTests(BasicACLTest):
         cloned_machine_ipaddress = self.get_machine_ipaddress(cloned_vm_id)
         self.assertTrue(cloned_machine_ipaddress)
 
+        self.lg('Check that the cloned vm has one boot disk and one metadata disk')
+        cloned_machine_info = self.api.cloudapi.machines.get(machineId=cloned_vm_id)
+        self.assertEqual(len(cloned_machine_info['disks']), 2)
+        self.assertEqual(len([x for x in cloned_machine_info['disks'] if x['type'] == 'B']), 1)
+        self.assertEqual(len([x for x in cloned_machine_info['disks'] if x['type'] == 'M']), 1)
+    
         self.lg('Start (VM1), should succeed')
         self.api.cloudapi.machines.start(machineId=machineId)
 


### PR DESCRIPTION
fixes #306 
```
root@be-g8-3:/tmp/ahmed/G8_testing/functional_testing/Openvcloud# nosetests -s -v ovc_master_hosted/OVC/c_advanced/machine_tests.py:MachineTests.test010_check_cloned_vm --tc-file config.ini 
/usr/local/lib/python2.7/dist-packages/nose_parameterized/__init__.py:7: UserWarning: The 'nose-parameterized' package has been renamed 'parameterized'. For the two step migration instructions, see: https://github.com/wolever/parameterized#migrating-from-nose-parameterized-to-parameterized (set NOSE_PARAMETERIZED_NO_WARN=1 to suppress this warning)
  "The 'nose-parameterized' package has been renamed 'parameterized'. "
OVC-029 ... HTTP Error 409: Conflict
ok

----------------------------------------------------------------------
Ran 1 test in 162.217s

OK
root@be-g8-3:/tmp/ahmed/G8_testing/functional_testing/Openvcloud# 

```