### PR TITLE
Task 234

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
@@ -235,7 +235,7 @@ class NetworkBasicTests(BasicACLTest):
 
 
     def test005_external_network_with_empty_vlan(self):
-        """ OVC-056
+        """ OVC-051
         * Test case for moving virtual firewall form one node to another
 
         **Test Scenario:**
@@ -255,7 +255,6 @@ class NetworkBasicTests(BasicACLTest):
             startip = base + '.10'
             endip = base + '.20'
             gid = j.application.whoAmI.gid
-
             external_network_id = self.api.cloudbroker.iaas.addExternalNetwork(
                 name=name,
                 subnet=subnet,
@@ -270,10 +269,8 @@ class NetworkBasicTests(BasicACLTest):
             external_network_info = osis_client.externalnetwork.get(external_network_id)
             self.lg("Check that external network (EN1)'s vlan tag equal to 0, should succeed")
             self.assertEqual(external_network_info.vlan, 0)
-
         except:
             raise
-
         finally:
             self.lg('Remove  external network (EN1), should succeed')
             self.api.cloudbroker.iaas.deleteExternalNetwork(external_network_id)

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
@@ -269,7 +269,7 @@ class NetworkBasicTests(BasicACLTest):
             osis_client = j.clients.osis.getNamespace('cloudbroker')
             external_network_info = osis_client.externalnetwork.get(external_network_id)
             self.lg("Check that external network (EN1)'s vlan tag equal to 0, should succeed")
-            self.assertTrue(external_network_info['vlan'], 0)
+            self.assertTrue(external_network_info.vlan, 0)
 
         except:
             raise

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
@@ -269,7 +269,7 @@ class NetworkBasicTests(BasicACLTest):
             osis_client = j.clients.osis.getNamespace('cloudbroker')
             external_network_info = osis_client.externalnetwork.get(external_network_id)
             self.lg("Check that external network (EN1)'s vlan tag equal to 0, should succeed")
-            self.assertTrue(external_network_info.vlan, 0)
+            self.assertEqual(external_network_info.vlan, 0)
 
         except:
             raise

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
@@ -236,7 +236,7 @@ class NetworkBasicTests(BasicACLTest):
 
     def test005_external_network_with_empty_vlan(self):
         """ OVC-051
-        * Test case for moving virtual firewall form one node to another
+        * Test case for creating external network with empty vlan tag
 
         **Test Scenario:**
 
@@ -246,15 +246,16 @@ class NetworkBasicTests(BasicACLTest):
         #. Remove external network (EN1), should succeed.
         """
 
+        self.lg('Create external network (EN1) with empty vlan tag, should succeed')
+        name = 'test-external-network'
+        base = '.'.join([str(random.randint(0, 254)) for i in range(3)])
+        subnet = base + '.0/24'
+        gateway = base + '.1'
+        startip = base + '.10'
+        endip = base + '.20'
+        gid = j.application.whoAmI.gid
+    
         try:
-            self.lg('Create external network (EN1) with empty vlan tag, should succeed')
-            name = 'test-external-network'
-            base = '.'.join([str(random.randint(0, 254)) for i in range(3)])
-            subnet = base + '.0/24'
-            gateway = base + '.1'
-            startip = base + '.10'
-            endip = base + '.20'
-            gid = j.application.whoAmI.gid
             external_network_id = self.api.cloudbroker.iaas.addExternalNetwork(
                 name=name,
                 subnet=subnet,
@@ -263,7 +264,6 @@ class NetworkBasicTests(BasicACLTest):
                 endip=endip,
                 gid=gid
             )
-
             self.lg("Get external network (EN1)'s info using osis client")
             osis_client = j.clients.osis.getNamespace('cloudbroker')
             external_network_info = osis_client.externalnetwork.get(external_network_id)

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/network_tests.py
@@ -231,5 +231,51 @@ class NetworkBasicTests(BasicACLTest):
 
         self.wait_for_status('DEPLOYED', self.account_owner_api.cloudapi.cloudspaces.get,
                              cloudspaceId=self.cloudspace_id)
-        self.lg('%s ENDED' % self._testID)        
+        self.lg('%s ENDED' % self._testID)
+
+
+    def test005_external_network_with_empty_vlan(self):
+        """ OVC-056
+        * Test case for moving virtual firewall form one node to another
+
+        **Test Scenario:**
+
+        #. Create external network (EN1) with empty vlan tag, should succeed.
+        #. Get external network (EN1)'s info using osis client.
+        #. Check that external network (EN1)'s vlan tag equal to 0, should succeed.
+        #. Remove external network (EN1), should succeed.
+        """
+
+        try:
+            self.lg('Create external network (EN1) with empty vlan tag, should succeed')
+            name = 'test-external-network'
+            base = '.'.join([str(random.randint(0, 254)) for i in range(3)])
+            subnet = base + '.0/24'
+            gateway = base + '.1'
+            startip = base + '.10'
+            endip = base + '.20'
+            gid = j.application.whoAmI.gid
+
+            external_network_id = self.api.cloudbroker.iaas.addExternalNetwork(
+                name=name,
+                subnet=subnet,
+                gateway=gateway,
+                startip=startip,
+                endip=endip,
+                gid=gid
+            )
+
+            self.lg("Get external network (EN1)'s info using osis client")
+            osis_client = j.clients.osis.getNamespace('cloudbroker')
+            external_network_info = osis_client.externalnetwork.get(external_network_id)
+            self.lg("Check that external network (EN1)'s vlan tag equal to 0, should succeed")
+            self.assertTrue(external_network_info['vlan'], 0)
+
+        except:
+            raise
+
+        finally:
+            self.lg('Remove  external network (EN1), should succeed')
+            self.api.cloudbroker.iaas.deleteExternalNetwork(external_network_id)
+
 


### PR DESCRIPTION
fixes #234 

```
root@be-g8-3:/tmp/ahmed/G8_testing/functional_testing/Openvcloud# nosetests -s -v ovc_master_hosted/OVC/a_basic/network_tests.py:NetworkBasicTests.test005_external_network_with_empty_vlan --tc-file config.ini 
/usr/local/lib/python2.7/dist-packages/nose_parameterized/__init__.py:7: UserWarning: The 'nose-parameterized' package has been renamed 'parameterized'. For the two step migration instructions, see: https://github.com/wolever/parameterized#migrating-from-nose-parameterized-to-parameterized (set NOSE_PARAMETERIZED_NO_WARN=1 to suppress this warning)
  "The 'nose-parameterized' package has been renamed 'parameterized'. "
OVC-056 ... ok

----------------------------------------------------------------------
Ran 1 test in 48.532s

OK

```