### PR TITLE
cover zero access portal pages

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/Navigation/left_navigation_menu.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/Navigation/left_navigation_menu.py
@@ -41,6 +41,9 @@ class CloudBroker():
     def StorageRouters(self):
         self.framework.open_base_page("cloud_broker","cloudbroker_sub_sr")
 
+    def ZeroAccess(self):
+        self.framework.open_base_page("cloud_broker","cloudbroker_sub_0_access")
+
     def SoftwareVersions(self):
         self.framework.open_base_page("cloud_broker","cloudbroker_sub_sv")
 

--- a/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/framework.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/framework.py
@@ -14,6 +14,7 @@ from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.workflow.l
 from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.workflow.tables import tables
 from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.pages.admin_portal.cloud_broker.Images import images
 from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.pages.admin_portal.cloud_broker.storagerouters import storagerouters
+from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.pages.admin_portal.cloud_broker.zero_access import zero_access
 
 class Framework(BaseTest):
     def __init__(self, *args, **kwargs):
@@ -29,6 +30,7 @@ class Framework(BaseTest):
         #Pages.AdminPortal.grid
         self.ErrorConditions = errorConditions(self)
         self.StatusOverview = statusOverview(self)
+        self.ZeroAccess = zero_access(self)
 
         #pages.end_user
         self.EUHome = home(self)

--- a/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/pages/admin_portal/cloud_broker/zero_access.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/pages/admin_portal/cloud_broker/zero_access.py
@@ -1,0 +1,54 @@
+import time
+import uuid
+from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.Navigation.left_navigation_menu import leftNavigationMenu
+
+
+class zero_access():
+    def __init__(self, framework):
+        self.framework = framework
+        self.LeftNavigationMenu = leftNavigationMenu(framework)
+
+    def get_it(self):
+        self.LeftNavigationMenu.CloudBroker.ZeroAccess()
+
+    def is_at(self):
+        for _ in range(10):
+            if '0-access' in self.framework.driver.title:
+                return True
+            else:
+                time.sleep(1)
+        else:
+            return False
+
+    def open_node_page(self, node=None):
+        self.LeftNavigationMenu.CloudBroker.ZeroAccess()
+
+        if not node:
+            table = self.framework.Tables.generate_table_elements('zero_access_nodes')
+            random_node = self.framework.Tables.get_random_row_from_table(table)
+            node = random_node[0]
+
+        self.framework.set_text("zero_access_nodes_search", node)
+        if self.framework.wait_until_element_located_and_has_text("zero_access_nodes_first_element", node):
+            self.framework.click('zero_access_nodes_first_element')
+            return True
+        else:
+            self.framework.lg('can\'t find node %s' % node)
+            return False
+
+
+    def open_session_page(self, session=None):
+        self.LeftNavigationMenu.CloudBroker.ZeroAccess()
+
+        if not session:
+            table = self.framework.Tables.generate_table_elements('zero_access_sessions')
+            random_session = self.framework.Tables.get_random_row_from_table(table)
+            session = random_session[0]
+
+        self.framework.set_text("zero_access_sessions_search", session)
+        if self.framework.wait_until_element_located_and_has_text("zero_access_sessions_first_element", session):
+            self.framework.click('zero_access_sessions_first_element')
+            return True
+        else:
+            self.framework.lg('can\'t find session %s' % session)
+            return False

--- a/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/xpath.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/Portal/framework/xpath.py
@@ -65,6 +65,16 @@ elements = {
             'table_groups_pagination':['ID','DataTables_Table_0_paginate'],
             'table_groups_search_box':['XPATH','//*[@id="DataTables_Table_0_filter"]/label/input'],
 
+            'table_zero_access_nodes_data':['ID','DataTables_Table_0'],
+            'table_zero_access_nodes_info':['ID','DataTables_Table_0_info'],
+            'table_zero_access_nodes_selector':['NAME','DataTables_Table_0_length', 0],
+            'table_zero_access_nodes_pagination':['ID','DataTables_Table_0_paginate'],
+
+            'table_zero_access_sessions_data':['ID','DataTables_Table_1'],
+            'table_zero_access_sessions_info':['ID','DataTables_Table_1_info'],
+            'table_zero_access_sessions_selector':['NAME','DataTables_Table_1_length', 0],
+            'table_zero_access_sessions_pagination':['ID','DataTables_Table_1_paginate'],
+        
             'snapshot_ok_button': ['XPATH', 'html/body/div[3]/form/div[3]/button[1]'],
             'storage_arrow': ['XPATH', 'html/body/div[1]/div/div[1]/div/nav/div/ul/li[5]/ul[1]/a[1]'],
             'user_delete_confirm': ['XPATH', ".//*[@id='action-Delete']/div/div[3]/button[2]"],
@@ -402,7 +412,8 @@ elements = {
             'knowledge_base_line6_tab_image8': ['XPATH',
                                                 ".//*[@id='wrap']/div/tour/div[3]/div[2]/div/div/div/div[2]/p[16]/img"],
             'cloudbroker_sub_sr': ['XPATH', ".//*[@id='collapse-2']/li[11]/a"],
-            'cloudbroker_sub_sv': ['XPATH', ".//*[@id='collapse-2']/li[12]/a"],
+            'cloudbroker_sub_0_access': ['XPATH', ".//*[@id='collapse-2']/li[12]/a"],
+            'cloudbroker_sub_sv': ['XPATH', ".//*[@id='collapse-2']/li[13]/a"],
             'windows_2012': ['XPATH', ".//*[@id='Windows']/ul/button"], 'machine_description_': ['XPATH',
                                                                                                  ".//*[@id='wrap']/div/tour/div[3]/div[2]/div/div/div/div[2]/div/div/div/div[2]/textarea"],
             'machines_line11_label': ['XPATH', ".//*[@id='wrap']/div/tour/div[3]/div[2]/div/div/div/div[2]/p"],
@@ -797,6 +808,11 @@ elements = {
             'delete_account_dialog':['ID','action-Delete'],
             'delete_cloudspace_dialog':['ID','action-DeleteCloudSpace'],
             'delete_vm_dialog':['ID','action-Delete'],
-            'edit_account_dialog':['ID','action-Edit']
+            'edit_account_dialog':['ID','action-Edit'],
+
+            'zero_access_nodes_search': ['XPATH', '//*[@id="DataTables_Table_0"]/tfoot/td[1]/input'],
+            'zero_access_sessions_search': ['XPATH', '//*[@id="DataTables_Table_1"]/tfoot/td[1]/input'],
+            'zero_access_nodes_first_element': ['XPATH', "//*[@id='DataTables_Table_0']/tbody/tr[1]/td[1]"],
+            'zero_access_sessions_first_element': ['XPATH', "//*[@id='DataTables_Table_1']/tbody/tr[1]/td[1]"],
 
             }

--- a/functional_testing/Openvcloud/ovc_master_hosted/Portal/testcases/admin_portal/cloud_broker/test07_zero_access.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/Portal/testcases/admin_portal/cloud_broker/test07_zero_access.py
@@ -1,0 +1,86 @@
+import unittest
+from nose_parameterized import parameterized
+from functional_testing.Openvcloud.ovc_master_hosted.Portal.framework.framework import Framework
+
+class ZeroAccessTests(Framework):
+    def setUp(self):
+        super(ZeroAccessTests, self).setUp()
+        self.Login.Login(username=self.admin_username, password=self.admin_password)
+        self.navigation_bar = 'navigation bar'
+        self.lg('go to zero access page')
+        self.ZeroAccess.get_it()
+        self.assertTrue(self.ZeroAccess.is_at())
+
+    def test01_zero_access_page_basic_elements(self):
+        """
+        PRTL-001
+        *Test case to make sure the basic elements in zero access page as expected*
+
+        **Test Scenario:**
+        #. go to zero access page
+        #. check page url & title
+        #. check navigation bar
+        #. check page title
+        #. check 'show records per page' list
+        """
+        self.lg('check page url & title')
+        self.assertEqual(self.driver.title, 'CBGrid - 0-access')
+        self.assertIn('cbgrid/0-access', self.driver.current_url)
+        self.lg('check navigation bar')
+        self.assertEqual(self.get_navigation_bar(self.navigation_bar), ['Cloud Broker', '0-access'])
+
+    def test02_zero_access_nodes_table_paging(self):
+        """
+        PRTL-002
+        *Test case to make sure that show 'records per page' of zero access nodes's table is working as expected*
+
+        **Test Scenario:**
+        #. go to zero access page.
+        #. try paging from the available page numbers and verify it should succeed.
+        """
+        self.lg('%s STARTED' % self._testID)
+        self.lg('try paging from the available page numbers and verify it should succeed')
+        self.assertTrue(self.Tables.check_show_list('zero_access_nodes'))
+        self.lg('%s ENDED' % self._testID)
+
+    def test03_zero_access_nodes_table_paging_buttons(self):
+        """
+        PRTL-003
+        *Test case to make sure that paging of zero access nodes's table is working as expected*
+
+        **Test Scenario:**
+        #. go to zero access page.
+        #. try paging from start/previous/next/last and verify it should succeed.
+        """
+        self.lg('%s STARTED' % self._testID)
+        self.lg('try paging from start/previous/next/last and verify it should succeed')
+        self.assertTrue(self.Tables.check_next_previous_buttons('zero_access_nodes'))
+        self.lg('%s ENDED' % self._testID)
+
+    def test04_zero_access_sessions_table_paging(self):
+        """
+        PRTL-004
+        *Test case to make sure that show 'records per page' of zero access sessions's table is working as expected*
+
+        **Test Scenario:**
+        #. go to zero access page.
+        #. try paging from the available page numbers and verify it should succeed.
+        """
+        self.lg('%s STARTED' % self._testID)
+        self.lg('try paging from the available page numbers and verify it should succeed')
+        self.assertTrue(self.Tables.check_show_list('zero_access_sessions'))
+        self.lg('%s ENDED' % self._testID)
+
+    def test05_zero_access_sessions_table_paging_buttons(self):
+        """
+        PRTL-005
+        *Test case to make sure that paging of zero access sessions's table is working as expected*
+
+        **Test Scenario:**
+        #. go to storage routers page.
+        #. try paging from start/previous/next/last and verify it should succeed.
+        """
+        self.lg('%s STARTED' % self._testID)
+        self.lg('try paging from start/previous/next/last and verify it should succeed')
+        self.assertTrue(self.Tables.check_next_previous_buttons('zero_access_sessions'))
+        self.lg('%s ENDED' % self._testID)


### PR DESCRIPTION
```
 % xvfb-run -a nosetests-2.7 -s -v testcases/admin_portal/cloud_broker/test07_zero_access.py --tc-file config.ini/usr/local/lib/python2.7/dist-packages/nose_parameterized/__init__.py:7: UserWarning: The 'nose-parameterized' package has been renamed 'parameterized'. For the two step
migration instructions, see: https://github.com/wolever/parameterized#migrating-from-nose-parameterized-to-parameterized (set NOSE_PARAMETERIZED_NO_WARN=1 to suppress thi
s warning)
  "The 'nose-parameterized' package has been renamed 'parameterized'. "
PRTL-001 ... ok
PRTL-002 ... ok
PRTL-003 ... ok
PRTL-004 ... ok
PRTL-005 ... ok

----------------------------------------------------------------------
Ran 5 tests in 269.762s

OK
```