### PR TITLE
Task 322

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
@@ -303,6 +303,7 @@ class BasicTests(BasicACLTest):
         #. Take 6 different snapshots for the created virtual machine
         #. Rollback to the 3rd snapshot
         #. check if the rolling back have succeed
+        #. create snapshot by passing number in the name param and then list snapshots, should succeed.
         #. disable the account, should succeed
         #. Try to create snapshot, should fail with 403 forbidden
         #. Try to start the VM, should fail with 403 forbidden

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
@@ -392,7 +392,7 @@ class BasicTests(BasicACLTest):
         finally:
             self.execute_command_on_physical_node('cd; rm machine_script.py', nodeID)
         
-        self.lg('- create snapshot with name is number and then list snapshots, should succeed')
+        self.lg('- create snapshot by passing number in the name param and then list snapshots, should succeed')
         name = str(random.randint(10,100))
         self.account_owner_api.cloudapi.machines.snapshot(machineId=self.machine_id, name=name)
         snapshots = self.account_owner_api.cloudapi.machines.listSnapshots(machineId=self.machine_id)

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
@@ -411,6 +411,12 @@ class BasicTests(BasicACLTest):
         self.lg('- expected error raised %s' % e.exception.message)
         self.assertEqual(e.exception.message, '403 Forbidden')
 
+        self.lg('- create snapshot with name is number and then list snapshots')
+        name = str(random.randint(1,10))
+        self.account_owner_api.cloudapi.machines.snapshot(machineId=self.machine_id, name=name)
+        snapshots = self.account_owner_api.cloudapi.machines.listSnapshots(machineId=self.machine_id)
+        self.assertIn(name, [x['name'] for x in snapshots])
+
         self.lg('%s ENDED' % self._testID)
 
     def test007_cleanup_vxlans_for_stopped_deleted_vms(self):

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
@@ -411,8 +411,8 @@ class BasicTests(BasicACLTest):
         self.lg('- expected error raised %s' % e.exception.message)
         self.assertEqual(e.exception.message, '403 Forbidden')
 
-        self.lg('- create snapshot with name is number and then list snapshots')
-        name = str(random.randint(1,10))
+        self.lg('- create snapshot with name is number and then list snapshots, should succeed')
+        name = str(random.randint(10,100))
         self.account_owner_api.cloudapi.machines.snapshot(machineId=self.machine_id, name=name)
         snapshots = self.account_owner_api.cloudapi.machines.listSnapshots(machineId=self.machine_id)
         self.assertIn(name, [x['name'] for x in snapshots])

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/a_basic/machine_tests.py
@@ -391,6 +391,12 @@ class BasicTests(BasicACLTest):
             self.assertEqual('3', count_files[0])
         finally:
             self.execute_command_on_physical_node('cd; rm machine_script.py', nodeID)
+        
+        self.lg('- create snapshot with name is number and then list snapshots, should succeed')
+        name = str(random.randint(10,100))
+        self.account_owner_api.cloudapi.machines.snapshot(machineId=self.machine_id, name=name)
+        snapshots = self.account_owner_api.cloudapi.machines.listSnapshots(machineId=self.machine_id)
+        self.assertIn(name, [x['name'] for x in snapshots])
 
         self.lg('- disable the account, should succeed')
         self.api.cloudbroker.account.disable(accountId=self.account_id, reason='testing')
@@ -410,12 +416,6 @@ class BasicTests(BasicACLTest):
 
         self.lg('- expected error raised %s' % e.exception.message)
         self.assertEqual(e.exception.message, '403 Forbidden')
-
-        self.lg('- create snapshot with name is number and then list snapshots, should succeed')
-        name = str(random.randint(10,100))
-        self.account_owner_api.cloudapi.machines.snapshot(machineId=self.machine_id, name=name)
-        snapshots = self.account_owner_api.cloudapi.machines.listSnapshots(machineId=self.machine_id)
-        self.assertIn(name, [x['name'] for x in snapshots])
 
         self.lg('%s ENDED' % self._testID)
 


### PR DESCRIPTION
fixes #322
```
/usr/local/lib/python2.7/dist-packages/nose_parameterized/__init__.py:7: UserWarning: The 'nose-parameterized' package has been renamed 'parameterized'. For the two step migration instructions, see: https://github.com/wolever/parameterized#migrating-from-nose-parameterized-to-parameterized (set NOSE_PARAMETERIZED_NO_WARN=1 to suppress this warning)
  "The 'nose-parameterized' package has been renamed 'parameterized'. "
OVC-006 ... ok

----------------------------------------------------------------------
Ran 1 test in 393.230s

OK
```