### PR TITLE
(Task 318) cover vfw apis 

### DIFF
--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
@@ -209,7 +209,7 @@ class CloudspaceTests(BasicACLTest):
         self.api.cloudapi.machines.delete(machineId=machineId)
 
     def test005_get_stop_start_destroy_deploy_vfw(self):
-        """ OVC-04x
+        """ OVC-056
         *Test case for test start stop move destroy virtual firewall.*
 
         **Test Scenario:**
@@ -272,7 +272,7 @@ class CloudspaceTests(BasicACLTest):
         self.assertIn('Linux', stdout.read())
 
     def test006_move_vfw(self):
-        """ OVC-04x
+        """ OVC-057
         *Test case for test start stop move remove virtual firewall.*
 
         **Test Scenario:**
@@ -330,7 +330,7 @@ class CloudspaceTests(BasicACLTest):
         self.assertIn('Linux', stdout.read())
 
     def test007_reset_vfw(self):
-        """ OVC-04x
+        """ OVC-058
         *Test case for test start stop move remove virtual firewall.*
 
         **Test Scenario:**
@@ -360,7 +360,7 @@ class CloudspaceTests(BasicACLTest):
                     public_port=public_port,
                     local_port=local_port
                 )
-                
+
         self.api.cloudapi.cloudspaces.executeRouterOSScript(self.cloudspace_id, script=script)
 
         self.lg('Try to connect to virtual machine (VM1) through PF1, should succeed')

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
@@ -258,10 +258,6 @@ class CloudspaceTests(BasicACLTest):
             self.api.cloudbroker.cloudspace.getVFW(self.cloudspace_id)
         self.assertEqual(e.exception.status_code, 400)
 
-        self.lg('Try to connect to vm (VM1), should fail')
-        with self.assertRaises(socket.error):
-            VMClient(machine_id, timeout=1)
-
         self.lg('Deploy new vfw for cloudspace (CS1), should succeed')
         self.api.cloudbroker.cloudspace.deployVFW(self.cloudspace_id)
         self.wait_for_status('DEPLOYED', self.api.cloudapi.cloudspaces.get, cloudspaceId=self.cloudspace_id)

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
@@ -1,4 +1,4 @@
-#import random
+# coding=utf-8
 import unittest, socket, random
 from ....utils.utils import BasicACLTest, VMClient
 from JumpScale.portal.portal.PortalClient2 import ApiError

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
@@ -367,7 +367,7 @@ class CloudspaceTests(BasicACLTest):
         self.lg('Reset cloudspace (CS1)\'s vfw, should succeed')
         self.api.cloudbroker.cloudspace.resetVFW(self.cloudspace_id, resettype='factory')
 
-        self.lg('Try to connect to virtual machine (VM1) through PF1, should fail')
+        self.lg('Try to connect to virtual machine (VM1) through portforward (PF1), should fail')
         with self.assertRaises(socket.error):
             VMClient(machine_id, port=public_port, timeout=1)
 

--- a/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
+++ b/functional_testing/Openvcloud/ovc_master_hosted/OVC/b_extended/cloudspace_tests.py
@@ -360,7 +360,7 @@ class CloudspaceTests(BasicACLTest):
                     public_port=public_port,
                     local_port=local_port
                 )
-l
+                
         self.api.cloudapi.cloudspaces.executeRouterOSScript(self.cloudspace_id, script=script)
 
         self.lg('Try to connect to virtual machine (VM1) through PF1, should succeed')

--- a/functional_testing/Openvcloud/utils/utils.py
+++ b/functional_testing/Openvcloud/utils/utils.py
@@ -521,7 +521,7 @@ class BaseTest(unittest.TestCase):
         return ssh_client
 
     def get_running_nodeId(self, except_nodeid=None):
-        nodes = cloudbroker.computenode.list()
+        nodes = self.api.cloudbroker.computenode.list()
         for node in nodes:
             if int(node['id']) != except_nodeid and node['status'] == 'ENABLED':
                 return node['id']

--- a/functional_testing/Openvcloud/utils/utils.py
+++ b/functional_testing/Openvcloud/utils/utils.py
@@ -524,7 +524,7 @@ class BaseTest(unittest.TestCase):
         nodes = self.api.cloudbroker.computenode.list()
         for node in nodes:
             if int(node['referenceId']) != except_nodeid and node['status'] == 'ENABLED':
-                return node['referenceId']
+                return int(node['referenceId'])
         else:
             return None
 

--- a/functional_testing/Openvcloud/utils/utils.py
+++ b/functional_testing/Openvcloud/utils/utils.py
@@ -520,6 +520,13 @@ class BaseTest(unittest.TestCase):
         ssh_client.connect(vm_ip, username=login, password=password)
         return ssh_client
 
+    def get_running_nodeId(self, except_nodeid=None):
+        nodes = cloudbroker.computenode.list()
+        for node in nodes:
+            if int(node['id']) != except_nodeid and node['status'] == 'ENABLED':
+                return node['id']
+        else:
+            return None
 
     def get_running_stackId(self, except_stackid=''):
         ccl = j.clients.osis.getNamespace('cloudbroker')

--- a/functional_testing/Openvcloud/utils/utils.py
+++ b/functional_testing/Openvcloud/utils/utils.py
@@ -523,8 +523,8 @@ class BaseTest(unittest.TestCase):
     def get_running_nodeId(self, except_nodeid=None):
         nodes = self.api.cloudbroker.computenode.list()
         for node in nodes:
-            if int(node['id']) != except_nodeid and node['status'] == 'ENABLED':
-                return node['id']
+            if int(node['referenceId']) != except_nodeid and node['status'] == 'ENABLED':
+                return node['referenceId']
         else:
             return None
 


### PR DESCRIPTION
fixes #318 

```
root@be-g8-3:/tmp/ahmed/G8_testing/functional_testing/Openvcloud# nosetests -v -s --tests ovc_master_hosted/OVC/b_extended/cloudspace_tests.py:CloudspaceTests.test005_get_stop_start_destroy_deploy_vfw,ovc_master_hosted/OVC/b_extended/cloudspace_tests.py:CloudspaceTests.test006_move_vfw,ovc_master_hosted/OVC/b_extended/cloudspace_tests.py:CloudspaceTests.test007_reset_vfw --tc-file config.ini
OVC-056 ... HTTP Error 400: Bad Request
ok
OVC-057 ... ok
OVC-058 ... HTTP Error 400: Bad Request
ok

----------------------------------------------------------------------
Ran 3 tests in 728.167s

OK
```